### PR TITLE
feat: add option to update only non dev dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,12 +12,14 @@ program
   .version(version)
   .description(description)
   .option('-D, --dev', 'update only devDependencies')
+  .option('-N, --non-dev', 'update only non devDependencies')
 
 program.parse(process.argv)
 
-const args = []
 
-if (program.dev) args.push('-D')
+if (program.dev) package.dependencies = null
+if (program.nonDev) package.devDependencies = null
+
 
 const packageManager = fs.existsSync(path.resolve(process.cwd(), 'yarn.lock'))
   ? 'yarn'
@@ -32,7 +34,7 @@ const dependencies = [
 
 spawn(
   packageManager,
-  [installCommand[packageManager], ...dependencies, ...args],
+  [installCommand[packageManager], ...dependencies],
   {
     cwd: process.cwd(),
     stdio: 'inherit',

--- a/index.js
+++ b/index.js
@@ -11,14 +11,14 @@ const package = require(`${process.cwd()}/package.json`)
 program
   .version(version)
   .description(description)
-  .option('-D, --dev', 'update only devDependencies')
-  .option('-N, --non-dev', 'update only non devDependencies')
+  .option('-P, --prod', 'update only production dependencies')
+  .option('-D, --dev', 'update only development dependencies')
 
 program.parse(process.argv)
 
 
 if (program.dev) package.dependencies = null
-if (program.nonDev) package.devDependencies = null
+if (program.prod) package.devDependencies = null
 
 
 const packageManager = fs.existsSync(path.resolve(process.cwd(), 'yarn.lock'))


### PR DESCRIPTION
I was not very creative when it came to thinking about the flag for non-devs dependencies, and I can switch to any option you like best.

when I was developing I realized that when the -D flag was used it removed normal dependencies and added all of them as development dependencies, so I took the liberty to adjust that too.